### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/magicdrums/347681b4-e57c-4a93-857f-d86db5deb108/ee6d0b6c-7e06-4255-bddf-b38d57b73487/_apis/work/boardbadge/fd307544-dc5f-47cd-9925-0841eb227d11)](https://dev.azure.com/magicdrums/347681b4-e57c-4a93-857f-d86db5deb108/_boards/board/t/ee6d0b6c-7e06-4255-bddf-b38d57b73487/Microsoft.RequirementCategory)
 Versiones Finales!


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/magicdrums/347681b4-e57c-4a93-857f-d86db5deb108/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.